### PR TITLE
ughh, for some reason Google's library is logging a warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/MUXSDKImaListener.xcworkspace -scheme MUXSDKImaListener-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
-- pod lib lint
+- pod lib lint --allow-warnings


### PR DESCRIPTION
This is causing `pod spec lint` to fail in the final CI step. Solution for now: use `pod spec lint --allow-warnings` instead?

I get the same thing locally when I run `pod spec lint`, so this is kind of concerning...

https://travis-ci.org/github/muxinc/mux-stats-google-ima/builds/672285229

```
- WARN  | xcodebuild:  GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework/Headers/IMAAdDisplayContainer.h:61:2: warning: HTML start tag prematurely ended, expected attribute name or '>' [-Wdocumentation]
- WARN  | xcodebuild:  GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework/Headers/IMAAdsRequest.h:89:2: warning: HTML start tag prematurely ended, expected attribute name or '>' [-Wdocumentation]
- WARN  | xcodebuild:  GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework/Headers/IMAStreamRequest.h:72:2: warning: HTML start tag prematurely ended, expected attribute name or '>' [-Wdocumentation]
```