### PR TITLE
chore: fix up API prefixes to match other SDKs

### DIFF
--- a/Example/DemoApp/ViewController.swift
+++ b/Example/DemoApp/ViewController.swift
@@ -32,7 +32,7 @@ class ViewController: UIViewController, IMAAdsLoaderDelegate, IMAAdsManagerDeleg
     private var contentPlayhead: IMAAVPlayerContentPlayhead?
     
     // Mux SDK
-    private var imaListener: MuxImaListener?
+    private var adsListener: MUXSDKIMAAdsListener?
     private var playerBinding: MUXSDKPlayerBinding?
     
     
@@ -92,7 +92,7 @@ class ViewController: UIViewController, IMAAdsLoaderDelegate, IMAAdsManagerDeleg
         self.playerBinding = playerBinding
         
         // IMA Ads
-        imaListener = MuxImaListener(
+        adsListener = MUXSDKIMAAdsListener(
             playerBinding: playerBinding,
             monitoringAdsLoader: adsLoader
         )
@@ -125,7 +125,7 @@ class ViewController: UIViewController, IMAAdsLoaderDelegate, IMAAdsManagerDeleg
             userContext: nil)
         
         // MARK: mux - Tell us when you first request CSAI ads
-        imaListener?.clientAdRequest(request)
+        adsListener?.clientAdRequest(request)
         adsLoader.requestAds(with: request)
     }
     
@@ -150,7 +150,7 @@ class ViewController: UIViewController, IMAAdsLoaderDelegate, IMAAdsManagerDeleg
         adsManager.delegate = self
         
         //MARK: mux: Call before initialize() but after setting your IMAAdsManagerDelegate
-        imaListener?.monitorAdsManager(adsManager)
+        adsListener?.monitorAdsManager(adsManager)
         
         adsManager.initialize(with: nil)
     }

--- a/Example/MUXSDKIMATVOSExample/ViewController.swift
+++ b/Example/MUXSDKIMATVOSExample/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController, IMAAdsLoaderDelegate, IMAAdsManagerDeleg
   var playerViewController: AVPlayerViewController!
   var adBreakActive = false
   var playerBinding: MUXSDKPlayerBinding?
-  var imaListener: MuxImaListener?
+  var imaListener: MUXSDKIMAAdsListener?
 
   deinit {
     NotificationCenter.default.removeObserver(self)
@@ -181,7 +181,7 @@ extension ViewController {
         self.playerBinding = playerBinding
 
         // IMA Ads
-        imaListener = MuxImaListener(playerBinding: playerBinding)
+        imaListener = MUXSDKIMAAdsListener(playerBinding: playerBinding)
     }
 
 }

--- a/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.xcodeproj/project.pbxproj
+++ b/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		190698282BB37A3300CE0FF7 /* MuxStatsGoogleIMAPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 1906981C2BB37A3300CE0FF7 /* MuxStatsGoogleIMAPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		190698332BB37ABF00CE0FF7 /* MUXSDKStats in Frameworks */ = {isa = PBXBuildFile; productRef = 190698322BB37ABF00CE0FF7 /* MUXSDKStats */; };
 		1906983A2BB37B6700CE0FF7 /* GoogleInteractiveMediaAds in Frameworks */ = {isa = PBXBuildFile; productRef = 190698392BB37B6700CE0FF7 /* GoogleInteractiveMediaAds */; };
+		1915A2432CD188470094AA27 /* MuxImaListener+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A2402CD188470094AA27 /* MuxImaListener+Private.h */; };
+		1915A2442CD188470094AA27 /* MUXSDKIMAAdsListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A2412CD188470094AA27 /* MUXSDKIMAAdsListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1915A2452CD188470094AA27 /* MUXSDKIMAAdsListener+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A2422CD188470094AA27 /* MUXSDKIMAAdsListener+Private.h */; };
+		1915A2472CD188540094AA27 /* MUXSDKIMAAdsListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 1915A2462CD188540094AA27 /* MUXSDKIMAAdsListener.m */; };
 		198612452C22337F00E6A50C /* MuxImaListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 198612432C22337F00E6A50C /* MuxImaListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		198612462C22337F00E6A50C /* MuxImaListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 198612442C22337F00E6A50C /* MuxImaListener.m */; };
 /* End PBXBuildFile section */
@@ -31,6 +35,10 @@
 		1906981C2BB37A3300CE0FF7 /* MuxStatsGoogleIMAPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MuxStatsGoogleIMAPlugin.h; sourceTree = "<group>"; };
 		190698212BB37A3300CE0FF7 /* MuxStatsGoogleIMAPluginTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MuxStatsGoogleIMAPluginTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		190698262BB37A3300CE0FF7 /* MuxStatsGoogleIMAPluginTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MuxStatsGoogleIMAPluginTests.m; sourceTree = "<group>"; };
+		1915A2402CD188470094AA27 /* MuxImaListener+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MuxImaListener+Private.h"; path = "../../../Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener+Private.h"; sourceTree = "<group>"; };
+		1915A2412CD188470094AA27 /* MUXSDKIMAAdsListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKIMAAdsListener.h; path = ../../../Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h; sourceTree = "<group>"; };
+		1915A2422CD188470094AA27 /* MUXSDKIMAAdsListener+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MUXSDKIMAAdsListener+Private.h"; path = "../../../Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener+Private.h"; sourceTree = "<group>"; };
+		1915A2462CD188540094AA27 /* MUXSDKIMAAdsListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MUXSDKIMAAdsListener.m; path = ../../../Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m; sourceTree = "<group>"; };
 		198612432C22337F00E6A50C /* MuxImaListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MuxImaListener.h; path = ../../../Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener.h; sourceTree = "<group>"; };
 		198612442C22337F00E6A50C /* MuxImaListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MuxImaListener.m; path = ../../../Sources/MuxStatsGoogleIMAPlugin/MuxImaListener.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -79,6 +87,10 @@
 			children = (
 				198612432C22337F00E6A50C /* MuxImaListener.h */,
 				198612442C22337F00E6A50C /* MuxImaListener.m */,
+				1915A2402CD188470094AA27 /* MuxImaListener+Private.h */,
+				1915A2412CD188470094AA27 /* MUXSDKIMAAdsListener.h */,
+				1915A2462CD188540094AA27 /* MUXSDKIMAAdsListener.m */,
+				1915A2422CD188470094AA27 /* MUXSDKIMAAdsListener+Private.h */,
 				1906981C2BB37A3300CE0FF7 /* MuxStatsGoogleIMAPlugin.h */,
 			);
 			path = MuxStatsGoogleIMAPlugin;
@@ -101,6 +113,9 @@
 			files = (
 				190698282BB37A3300CE0FF7 /* MuxStatsGoogleIMAPlugin.h in Headers */,
 				198612452C22337F00E6A50C /* MuxImaListener.h in Headers */,
+				1915A2432CD188470094AA27 /* MuxImaListener+Private.h in Headers */,
+				1915A2442CD188470094AA27 /* MUXSDKIMAAdsListener.h in Headers */,
+				1915A2452CD188470094AA27 /* MUXSDKIMAAdsListener+Private.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -209,6 +224,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1915A2472CD188540094AA27 /* MUXSDKIMAAdsListener.m in Sources */,
 				198612462C22337F00E6A50C /* MuxImaListener.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.h
+++ b/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.h
@@ -13,4 +13,5 @@ FOUNDATION_EXPORT const unsigned char MuxStatsGoogleIMAPluginVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <MuxStatsGoogleIMAPlugin/PublicHeader.h>
 #import <MuxStatsGoogleIMAPlugin/MuxImaListener.h>
+#import <MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.h>
 

--- a/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.xcodeproj/project.pbxproj
+++ b/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		190698622BB37BF400CE0FF7 /* MUXSDKStats in Frameworks */ = {isa = PBXBuildFile; productRef = 190698612BB37BF400CE0FF7 /* MUXSDKStats */; };
 		190698652BB37C7400CE0FF7 /* GoogleInteractiveMediaAds in Frameworks */ = {isa = PBXBuildFile; productRef = 190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAds */; };
 		190698892BB3947F00CE0FF7 /* MuxStatsGoogleIMAPluginTVOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 190698522BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOSTests.m */; };
+		1915A2372CD186D40094AA27 /* MUXSDKIMAAdsListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A2362CD186D40094AA27 /* MUXSDKIMAAdsListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1915A2392CD186ED0094AA27 /* MUXSDKIMAAdsListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 1915A2382CD186ED0094AA27 /* MUXSDKIMAAdsListener.m */; };
+		1915A23D2CD187300094AA27 /* MuxImaListener+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A23C2CD187300094AA27 /* MuxImaListener+Private.h */; };
+		1915A23F2CD1874B0094AA27 /* MUXSDKIMAAdsListener+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A23E2CD1874B0094AA27 /* MUXSDKIMAAdsListener+Private.h */; };
 		198612412C22331700E6A50C /* MuxImaListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1986123F2C22331700E6A50C /* MuxImaListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		198612422C22331700E6A50C /* MuxImaListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 198612402C22331700E6A50C /* MuxImaListener.m */; };
 /* End PBXBuildFile section */
@@ -31,6 +35,10 @@
 		190698482BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MuxStatsGoogleIMAPluginTVOS.h; sourceTree = "<group>"; };
 		1906984D2BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MuxStatsGoogleIMAPluginTVOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		190698522BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOSTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MuxStatsGoogleIMAPluginTVOSTests.m; sourceTree = "<group>"; };
+		1915A2362CD186D40094AA27 /* MUXSDKIMAAdsListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKIMAAdsListener.h; path = ../../../Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h; sourceTree = "<group>"; };
+		1915A2382CD186ED0094AA27 /* MUXSDKIMAAdsListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MUXSDKIMAAdsListener.m; path = ../../../Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m; sourceTree = "<group>"; };
+		1915A23C2CD187300094AA27 /* MuxImaListener+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MuxImaListener+Private.h"; path = "../../../Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener+Private.h"; sourceTree = "<group>"; };
+		1915A23E2CD1874B0094AA27 /* MUXSDKIMAAdsListener+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MUXSDKIMAAdsListener+Private.h"; path = "../../../Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener+Private.h"; sourceTree = "<group>"; };
 		1986123F2C22331700E6A50C /* MuxImaListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MuxImaListener.h; path = ../../../Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener.h; sourceTree = "<group>"; };
 		198612402C22331700E6A50C /* MuxImaListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MuxImaListener.m; path = ../../../Sources/MuxStatsGoogleIMAPlugin/MuxImaListener.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -79,6 +87,10 @@
 			children = (
 				1986123F2C22331700E6A50C /* MuxImaListener.h */,
 				198612402C22331700E6A50C /* MuxImaListener.m */,
+				1915A23C2CD187300094AA27 /* MuxImaListener+Private.h */,
+				1915A2362CD186D40094AA27 /* MUXSDKIMAAdsListener.h */,
+				1915A2382CD186ED0094AA27 /* MUXSDKIMAAdsListener.m */,
+				1915A23E2CD1874B0094AA27 /* MUXSDKIMAAdsListener+Private.h */,
 				190698482BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.h */,
 			);
 			path = MuxStatsGoogleIMAPluginTVOS;
@@ -99,8 +111,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1915A2372CD186D40094AA27 /* MUXSDKIMAAdsListener.h in Headers */,
 				190698542BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.h in Headers */,
 				198612412C22331700E6A50C /* MuxImaListener.h in Headers */,
+				1915A23F2CD1874B0094AA27 /* MUXSDKIMAAdsListener+Private.h in Headers */,
+				1915A23D2CD187300094AA27 /* MuxImaListener+Private.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -209,6 +224,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1915A2392CD186ED0094AA27 /* MUXSDKIMAAdsListener.m in Sources */,
 				198612422C22331700E6A50C /* MuxImaListener.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.h
+++ b/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.h
@@ -13,4 +13,5 @@ FOUNDATION_EXPORT const unsigned char MuxStatsGoogleIMAPluginTVOSVersionString[]
 
 // In this header, you should import all the public headers of your framework using statements like #import <MuxStatsGoogleIMAPluginTVOS/PublicHeader.h>
 #import <MuxStatsGoogleIMAPluginTVOS/MuxImaListener.h>
+#import <MuxStatsGoogleIMAPluginTVOS/MUXSDKIMAAdsListener.h>
 

--- a/MuxStatsGoogleIMAPluginSPMExampleIOS/MuxStatsGoogleIMAPluginSPMExampleIOS/PlayerContainerViewController.swift
+++ b/MuxStatsGoogleIMAPluginSPMExampleIOS/MuxStatsGoogleIMAPluginSPMExampleIOS/PlayerContainerViewController.swift
@@ -36,7 +36,7 @@ class PlayerContainerViewController: UIViewController {
     )
     lazy var playerViewController = AVPlayerViewController()
 
-    var imaListener: MuxImaListener?
+    var adsListener: MUXSDKIMAAdsListener?
 
     // MARK: View controller lifecycle
 
@@ -87,7 +87,7 @@ class PlayerContainerViewController: UIViewController {
         }
 
         // MARK: Setup Mux Data IMA Plugin
-        imaListener = MuxImaListener(
+        adsListener = MUXSDKIMAAdsListener(
             playerBinding: playerBinding,
             monitoringAdsLoader: adsLoader
         )
@@ -146,7 +146,7 @@ class PlayerContainerViewController: UIViewController {
         adsLoader.requestAds(with: request)
 
         // Notify Mux Data about request
-        imaListener?.clientAdRequest(request)
+        adsListener?.clientAdRequest(request)
     }
 
     // MARK: deinit
@@ -171,7 +171,7 @@ extension PlayerContainerViewController: IMAAdsLoaderDelegate {
         
         // MARK: Monitor the IMAAdsManager with Mux
         // note - do this *after* setting your delegate but *before*
-        imaListener?.monitorAdsManager(loadedAdsManager)
+        adsListener?.monitorAdsManager(loadedAdsManager)
         
         let renderingSettings = IMAAdsRenderingSettings()
         renderingSettings.enablePreloading = true;

--- a/Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m
+++ b/Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m
@@ -50,7 +50,8 @@
         _adRequestReported = NO;
         _sendAdplayOnStarted = NO;
     }
-    return(self);
+
+    return self;
 }
 
 - (void)monitorAdsManager:(IMAAdsManager *)adsManager {

--- a/Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m
+++ b/Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m
@@ -1,0 +1,316 @@
+//
+//  MUXSDKIMAAdsListener.m
+//  MuxStatsGoogleIMAPlugin
+//
+
+#import <Foundation/Foundation.h>
+#import "MUXSDKIMAAdsListener.h"
+
+@interface MUXSDKIMAAdsListener ()
+
+@property (nonatomic, nonnull) MUXSDKPlayerBinding *playerBinding;
+
+@property (assign) BOOL sendAdplayOnStarted;
+@property (assign) BOOL isPictureInPicture;
+@property (assign) BOOL usesServerSideAdInsertion;
+@property (assign) BOOL adRequestReported;
+@property (assign) NSString *adTagURL;
+
+@end
+
+@implementation MUXSDKIMAAdsListener
+
+
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+      monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader {
+    return [self initWithPlayerBinding:binding
+                               options:MUXSDKIMAAdsListenerOptionsNone
+                   monitoringAdsLoader:adsLoader];
+}
+
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+                    options:(MUXSDKIMAAdsListenerOptions)options
+        monitoringAdsLoader:(IMAAdsLoader *)adsLoader {
+    self = [super init];
+
+    if (self) {
+        self.customerAdsLoaderDelegate = adsLoader.delegate;
+        adsLoader.delegate = self;
+
+        // The Ads Manager isn't created until further into the wokflow
+
+        _playerBinding = binding;
+        if ((options & MUXSDKIMAAdsListenerOptionsPictureInPicture) == MUXSDKIMAAdsListenerOptionsNone) {
+            _isPictureInPicture = NO;
+        }
+        if ((options & MUXSDKIMAAdsListenerOptionsPictureInPicture) == MUXSDKIMAAdsListenerOptionsPictureInPicture) {
+            _isPictureInPicture = YES;
+        }
+        _usesServerSideAdInsertion = NO;
+        _adRequestReported = NO;
+        _sendAdplayOnStarted = NO;
+    }
+    return(self);
+}
+
+- (void)monitorAdsManager:(IMAAdsManager *)adsManager {
+    self.customerAdsManagerDelegate = adsManager.delegate;
+    adsManager.delegate = self;
+}
+
+- (void)setupAdViewData:(MUXSDKAdEvent *)event withAd:(IMAAd *)ad {
+    MUXSDKViewData *viewData = [[MUXSDKViewData alloc] init];
+    MUXSDKAdData *adData = [[MUXSDKAdData alloc] init];
+    if (ad != nil) {
+        if ([_playerBinding getCurrentPlayheadTimeMs] < 1000) {
+            viewData.viewPrerollAdId = ad.adId;
+            viewData.viewPrerollCreativeId = ad.creativeID;
+        }
+        adData.adId = ad.adId;
+        adData.adCreativeId = ad.creativeID;
+
+        // TODO: use newer IMA API here. universalAdIdValue
+        // is deprecated, but used for time being for parity
+        // with web&android
+        adData.adUniversalId = ad.universalAdIdValue;
+        event.adData = adData;
+    }
+    event.viewData = viewData;
+}
+
+- (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEvent *)event {
+
+    MUXSDKAdData *adData = [[MUXSDKAdData alloc] init];
+    if (event.ad != nil) {
+        adData.adId = event.ad.adId;
+        adData.adCreativeId = event.ad.creativeID;
+
+        // TODO: use newer IMA API here. universalAdIdValue
+        // is deprecated, but used for time being for parity
+        // with web&android
+        adData.adUniversalId = event.ad.universalAdIdValue;
+    }
+
+    return [self dispatchEvent:event.type
+                    withAdData:adData
+                 withIMAAdData:event.adData];
+}
+
+- (nullable MUXSDKAdEvent *)dispatchEventOfType:(IMAAdEventType)eventType {
+    return [self dispatchEvent:eventType
+                    withAdData:nil
+                 withIMAAdData:nil];
+}
+
+- (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEventType)eventType
+                               withAdData:(nullable MUXSDKAdData *)adData
+                            withIMAAdData:(nullable NSDictionary *)imaAdData {
+    MUXSDKAdEvent *playbackEvent;
+
+    switch(eventType) {
+        case kIMAAdEvent_STARTED: {
+            if (_sendAdplayOnStarted) {
+                playbackEvent = [[MUXSDKAdPlayEvent alloc] init];
+                [_playerBinding dispatchAdEvent: playbackEvent];
+            } else {
+                _sendAdplayOnStarted = YES;
+            }
+            playbackEvent = [[MUXSDKAdPlayingEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_FIRST_QUARTILE: {
+            playbackEvent = [[MUXSDKAdFirstQuartileEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_MIDPOINT: {
+            playbackEvent = [[MUXSDKAdMidpointEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_THIRD_QUARTILE: {
+            playbackEvent = [[MUXSDKAdThirdQuartileEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_SKIPPED: {
+            playbackEvent = [[MUXSDKAdEndedEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_COMPLETE: {
+            playbackEvent = [[MUXSDKAdEndedEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_PAUSE: {
+            playbackEvent = [[MUXSDKAdPauseEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_RESUME: {
+            playbackEvent = [[MUXSDKAdPlayEvent alloc] init];
+            MUXSDKViewData *viewData = [[MUXSDKViewData alloc] init];
+            if ([_playerBinding getCurrentPlayheadTimeMs] < 1000) {
+                viewData.viewPrerollAdId = adData.adId;
+                viewData.viewPrerollCreativeId = adData.adCreativeId;
+            }
+            playbackEvent.viewData = viewData;
+            playbackEvent.adData = adData;
+            [_playerBinding dispatchAdEvent: playbackEvent];
+            playbackEvent = [[MUXSDKAdPlayingEvent alloc] init];
+            break;
+        }
+        case kIMAAdEvent_LOG: {
+            if (imaAdData && imaAdData[@"logData"]) {
+                NSDictionary *errorLog = (NSDictionary *)imaAdData[@"logData"];
+                if (errorLog) {
+                    if (errorLog[@"errorCode"] || errorLog[@"errorMessage"] || errorLog[@"type"]) {
+                        playbackEvent = [[MUXSDKAdErrorEvent alloc] init];
+                    }
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (playbackEvent != nil) {
+        MUXSDKViewData *viewData = [[MUXSDKViewData alloc] init];
+        if ([_playerBinding getCurrentPlayheadTimeMs] < 1000) {
+            viewData.viewPrerollAdId = adData.adId;
+            viewData.viewPrerollCreativeId = adData.adCreativeId;
+        }
+        playbackEvent.viewData = viewData;
+        playbackEvent.adData = adData;
+        [_playerBinding dispatchAdEvent:playbackEvent];
+        return playbackEvent;
+    } else {
+        return nil;
+    }
+}
+
+- (void)dispatchError:(NSString *)message {
+    MUXSDKAdEvent *playbackEvent = [[MUXSDKAdErrorEvent alloc] init];
+    [self setupAdViewData:playbackEvent withAd:nil];
+    [_playerBinding dispatchAdEvent:playbackEvent];
+}
+
+- (void)dispatchPauseOrResume:(BOOL)isPause {
+    MUXSDKAdEvent *playbackEvent;
+    if (isPause) {
+        if (_isPictureInPicture) {
+            [_playerBinding setAdPlaying:YES];
+        }
+        if (!_adRequestReported) {
+            // TODO: This is for backward compatability. Callers should call one of the *AdRequest methods. Remove this check in the next major rev
+            [self dispatchAdRequestWithoutMetadata];
+        }
+        MUXSDKAdEvent *playbackEvent = [[MUXSDKAdBreakStartEvent alloc] init];
+        [self setupAdViewData:playbackEvent withAd:nil];
+        [_playerBinding dispatchAdEvent: playbackEvent];
+
+        _sendAdplayOnStarted = NO;
+        [_playerBinding dispatchAdEvent: [[MUXSDKAdPlayEvent alloc] init]];
+
+        return;
+    } else {
+        if (_isPictureInPicture) {
+            [_playerBinding setAdPlaying:NO];
+        }
+        playbackEvent = [[MUXSDKAdBreakEndEvent alloc] init];
+        [self setupAdViewDataAndDispatchEvent: playbackEvent];
+        if (_usesServerSideAdInsertion) {
+            [_playerBinding dispatchPlay];
+            [_playerBinding dispatchPlaying];
+        }
+    }
+}
+
+- (void)onContentPauseOrResume:(BOOL)isPause {
+    [self dispatchPauseOrResume:isPause];
+}
+
+- (void)setupAdViewDataAndDispatchEvent:(MUXSDKAdEvent *) event {
+    [self setupAdViewData:event withAd:nil];
+    [_playerBinding dispatchAdEvent:event];
+}
+
+- (void)clientAdRequest:(IMAAdsRequest *)request {
+    _usesServerSideAdInsertion = NO;
+    _adRequestReported = YES;
+
+    [self dispatchAdRequestForAdTag:request.adTagUrl];
+}
+
+- (void)daiAdRequest:(IMAStreamRequest *)request {
+    _usesServerSideAdInsertion = YES;
+    _adRequestReported = YES;
+
+    [self dispatchAdRequestWithoutMetadata];
+}
+
+- (void)dispatchAdRequestWithoutMetadata {
+    MUXSDKAdEvent* playbackEvent = [[MUXSDKAdRequestEvent alloc] init];
+    [self setupAdViewDataAndDispatchEvent: playbackEvent];
+}
+
+- (void)dispatchAdRequestForAdTag:(nullable NSString *)adTagUrl {
+    MUXSDKAdEvent* playbackEvent = [[MUXSDKAdRequestEvent alloc] init];
+    MUXSDKAdData* adData = [[MUXSDKAdData alloc] init];
+    if(adTagUrl) {
+        self.adTagURL = adTagUrl;
+        adData.adTagUrl = adTagUrl;
+    }
+
+    [self setupAdViewDataAndDispatchEvent: playbackEvent];
+}
+
+- (void)setPictureInPicture:(BOOL)isPictureInPicture {
+    _isPictureInPicture = isPictureInPicture;
+}
+
+/* IMAAdsManagerDelegate */
+
+- (void)adsManager:(IMAAdsManager *)adsManager didReceiveAdEvent:(IMAAdEvent *)event {
+    if (self.customerAdsManagerDelegate) {
+        [self.customerAdsManagerDelegate adsManager:adsManager didReceiveAdEvent:event];
+    }
+    [self dispatchEvent: event];
+}
+
+- (void)adsManager:(nonnull IMAAdsManager *)adsManager didReceiveAdError:(nonnull IMAAdError *)error {
+    if (self.customerAdsManagerDelegate) {
+        [self.customerAdsManagerDelegate adsManager:adsManager didReceiveAdError:error];
+    }
+    [self dispatchError: error.message];
+}
+
+- (void)adsManagerDidRequestContentPause:(nonnull IMAAdsManager *)adsManager {
+    if (self.customerAdsManagerDelegate) {
+        [self.customerAdsManagerDelegate adsManagerDidRequestContentPause:adsManager];
+    }
+    // record content-pause last so adbreakstart happens after pause, to bracket the adbreak correctly
+    [self onContentPauseOrResume:true];
+}
+
+- (void)adsManagerDidRequestContentResume:(nonnull IMAAdsManager *)adsManager {
+    // record content-resume first so adbreakend happens before playing (brackets the ad break
+    [self onContentPauseOrResume:false];
+    if (self.customerAdsManagerDelegate) {
+        [self.customerAdsManagerDelegate adsManagerDidRequestContentResume:adsManager];
+    }
+}
+
+/* IMAAdsLoaderDelegate */
+
+- (void)adsLoader:(nonnull IMAAdsLoader *)loader adsLoadedWithData:(nonnull IMAAdsLoadedData *)adsLoadedData {
+    if (self.customerAdsLoaderDelegate) {
+        [self.customerAdsLoaderDelegate adsLoader:loader adsLoadedWithData:adsLoadedData];
+    }
+    [self.playerBinding dispatchAdEvent:[[MUXSDKAdResponseEvent alloc] init]];
+}
+
+- (void)adsLoader:(nonnull IMAAdsLoader *)loader failedWithErrorData:(nonnull IMAAdLoadingErrorData *)adErrorData {
+    if (self.customerAdsLoaderDelegate) {
+        [self.customerAdsLoaderDelegate adsLoader:loader failedWithErrorData:adErrorData];
+    }
+    [self dispatchError:adErrorData.adError.message];
+}
+
+@end

--- a/Sources/MuxStatsGoogleIMAPlugin/MuxImaListener.m
+++ b/Sources/MuxStatsGoogleIMAPlugin/MuxImaListener.m
@@ -6,314 +6,147 @@
 //
 
 #import "MuxImaListener.h"
+#import "MUXSDKIMAAdsListener.h"
+#import "MUXSDKIMAAdsListener+Private.h"
 
 @interface MuxImaListener ()
 
-@property (nonatomic, nonnull) MUXSDKPlayerBinding *playerBinding;
-
-@property (assign) BOOL sendAdplayOnStarted;
-@property (assign) BOOL isPictureInPicture;
-@property (assign) BOOL usesServerSideAdInsertion;
-@property (assign) BOOL adRequestReported;
-@property (assign) NSString *adTagURL;
+@property (nonatomic, strong) MUXSDKIMAAdsListener *adsListener;
 
 @end
 
 @implementation MuxImaListener
 
 
-- (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
       monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader {
-    return [
-        self initWithPlayerBinding:binding
-                           options:MuxImaListenerOptionsNone
-                     monitoringAdsLoader:adsLoader
-    ];
+    return [self initWithPlayerBinding:binding
+                               options:MuxImaListenerOptionsNone
+                   monitoringAdsLoader:adsLoader];
 }
 
-- (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
                     options:(MuxImaListenerOptions)options
                monitoringAdsLoader:(IMAAdsLoader *)adsLoader {
     self = [super init];
 
     if (self) {
-        self.customerAdsLoaderDelegate = adsLoader.delegate;
-        adsLoader.delegate = self;
-        
-        // The Ads Manager isn't created until further into the wokflow
-        
-        _playerBinding = binding;
-        if ((options & MuxImaListenerOptionsPictureInPicture) == MuxImaListenerOptionsNone) {
-            _isPictureInPicture = NO;
-        }
-        if ((options & MuxImaListenerOptionsPictureInPicture) == MuxImaListenerOptionsPictureInPicture) {
-            _isPictureInPicture = YES;
-        }
-        _usesServerSideAdInsertion = NO;
-        _adRequestReported = NO;
-        _sendAdplayOnStarted = NO;
+
+        MUXSDKIMAAdsListenerOptions adsListenerOptions = (options & MUXSDKIMAAdsListenerOptionsPictureInPicture) == 0 ?
+        MUXSDKIMAAdsListenerOptionsNone : MUXSDKIMAAdsListenerOptionsPictureInPicture;
+        _adsListener = [[MUXSDKIMAAdsListener alloc] initWithPlayerBinding:binding
+                                                                   options:adsListenerOptions
+                                                       monitoringAdsLoader:adsLoader];
     }
-    return(self);
+    return self;
+}
+
+- (nullable id<IMAAdsManagerDelegate>)customerAdsManagerDelegate {
+    return [self.adsListener customerAdsManagerDelegate];
+}
+
+- (void)setCustomerAdsManagerDelegate:(id<IMAAdsManagerDelegate>)customerAdsManagerDelegate {
+    [self.adsListener setCustomerAdsManagerDelegate:customerAdsManagerDelegate];
+}
+
+- (nullable id<IMAAdsLoaderDelegate>)customerAdsLoaderDelegate {
+    return [self.adsListener customerAdsLoaderDelegate];
+}
+
+- (void) setCustomerAdsLoaderDelegate:(id<IMAAdsLoaderDelegate>)customerAdsLoaderDelegate {
+    [self.adsListener setCustomerAdsLoaderDelegate:customerAdsLoaderDelegate];
 }
 
 - (void)monitorAdsManager:(IMAAdsManager *)adsManager {
-    self.customerAdsManagerDelegate = adsManager.delegate;
-    adsManager.delegate = self;
+    [self.adsListener monitorAdsManager:adsManager];
 }
 
 - (void)setupAdViewData:(MUXSDKAdEvent *)event withAd:(IMAAd *)ad {
-    MUXSDKViewData *viewData = [[MUXSDKViewData alloc] init];
-    MUXSDKAdData *adData = [[MUXSDKAdData alloc] init];
-    if (ad != nil) {
-        if ([_playerBinding getCurrentPlayheadTimeMs] < 1000) {
-            viewData.viewPrerollAdId = ad.adId;
-            viewData.viewPrerollCreativeId = ad.creativeID;
-        }
-        adData.adId = ad.adId;
-        adData.adCreativeId = ad.creativeID;
-        
-        // TODO: use newer IMA API here. universalAdIdValue
-        // is deprecated, but used for time being for parity
-        // with web&android
-        adData.adUniversalId = ad.universalAdIdValue;
-        event.adData = adData;
-    }
-    event.viewData = viewData;
+    [self.adsListener setupAdViewData:event
+                               withAd:ad];
 }
 
 - (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEvent *)event {
-
-    MUXSDKAdData *adData = [[MUXSDKAdData alloc] init];
-    if (event.ad != nil) {
-        adData.adId = event.ad.adId;
-        adData.adCreativeId = event.ad.creativeID;
-
-        // TODO: use newer IMA API here. universalAdIdValue
-        // is deprecated, but used for time being for parity
-        // with web&android
-        adData.adUniversalId = event.ad.universalAdIdValue;
-    }
-
-    return [self dispatchEvent:event.type
-                    withAdData:adData
-                 withIMAAdData:event.adData];
+    return [self.adsListener dispatchEvent:event];
 }
 
 - (nullable MUXSDKAdEvent *)dispatchEventOfType:(IMAAdEventType)eventType {
-    return [self dispatchEvent:eventType
-                    withAdData:nil
-                 withIMAAdData:nil];
+    return [self.adsListener dispatchEventOfType:eventType];
 }
 
 - (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEventType)eventType
                                withAdData:(nullable MUXSDKAdData *)adData
                             withIMAAdData:(nullable NSDictionary *)imaAdData {
-    MUXSDKAdEvent *playbackEvent;
-
-    switch(eventType) {
-        case kIMAAdEvent_STARTED: {
-            if (_sendAdplayOnStarted) {
-                playbackEvent = [[MUXSDKAdPlayEvent alloc] init];
-                [_playerBinding dispatchAdEvent: playbackEvent];
-            } else {
-                _sendAdplayOnStarted = YES;
-            }
-            playbackEvent = [[MUXSDKAdPlayingEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_FIRST_QUARTILE: {
-            playbackEvent = [[MUXSDKAdFirstQuartileEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_MIDPOINT: {
-            playbackEvent = [[MUXSDKAdMidpointEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_THIRD_QUARTILE: {
-            playbackEvent = [[MUXSDKAdThirdQuartileEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_SKIPPED: {
-            playbackEvent = [[MUXSDKAdEndedEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_COMPLETE: {
-            playbackEvent = [[MUXSDKAdEndedEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_PAUSE: {
-            playbackEvent = [[MUXSDKAdPauseEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_RESUME: {
-            playbackEvent = [[MUXSDKAdPlayEvent alloc] init];
-            MUXSDKViewData *viewData = [[MUXSDKViewData alloc] init];
-            if ([_playerBinding getCurrentPlayheadTimeMs] < 1000) {
-                viewData.viewPrerollAdId = adData.adId;
-                viewData.viewPrerollCreativeId = adData.adCreativeId;
-            }
-            playbackEvent.viewData = viewData;
-            playbackEvent.adData = adData;
-            [_playerBinding dispatchAdEvent: playbackEvent];
-            playbackEvent = [[MUXSDKAdPlayingEvent alloc] init];
-            break;
-        }
-        case kIMAAdEvent_LOG: {
-            if (imaAdData && imaAdData[@"logData"]) {
-                NSDictionary *errorLog = (NSDictionary *)imaAdData[@"logData"];
-                if (errorLog) {
-                    if (errorLog[@"errorCode"] || errorLog[@"errorMessage"] || errorLog[@"type"]) {
-                        playbackEvent = [[MUXSDKAdErrorEvent alloc] init];
-                    }
-                }
-            }
-            break;
-        }
-        default:
-            break;
-    }
-
-    if (playbackEvent != nil) {
-        MUXSDKViewData *viewData = [[MUXSDKViewData alloc] init];
-        if ([_playerBinding getCurrentPlayheadTimeMs] < 1000) {
-            viewData.viewPrerollAdId = adData.adId;
-            viewData.viewPrerollCreativeId = adData.adCreativeId;
-        }
-        playbackEvent.viewData = viewData;
-        playbackEvent.adData = adData;
-        [_playerBinding dispatchAdEvent:playbackEvent];
-        return playbackEvent;
-    } else {
-        return nil;
-    }
+    return [self.adsListener dispatchEvent:eventType
+                                withAdData:adData
+                             withIMAAdData:imaAdData];
 }
 
 - (void)dispatchError:(NSString *)message {
-    MUXSDKAdEvent *playbackEvent = [[MUXSDKAdErrorEvent alloc] init];
-    [self setupAdViewData:playbackEvent withAd:nil];
-    [_playerBinding dispatchAdEvent:playbackEvent];
+    [self.adsListener dispatchError:message];
 }
 
 - (void)dispatchPauseOrResume:(BOOL)isPause {
-    MUXSDKAdEvent *playbackEvent;
-    if (isPause) {
-        if (_isPictureInPicture) {
-            [_playerBinding setAdPlaying:YES];
-        }
-        if (!_adRequestReported) {
-            // TODO: This is for backward compatability. Callers should call one of the *AdRequest methods. Remove this check in the next major rev
-            [self dispatchAdRequestWithoutMetadata];
-        }
-        MUXSDKAdEvent *playbackEvent = [[MUXSDKAdBreakStartEvent alloc] init];
-        [self setupAdViewData:playbackEvent withAd:nil];
-        [_playerBinding dispatchAdEvent: playbackEvent];
-        
-        _sendAdplayOnStarted = NO;
-        [_playerBinding dispatchAdEvent: [[MUXSDKAdPlayEvent alloc] init]];
-
-        return;
-    } else {
-        if (_isPictureInPicture) {
-            [_playerBinding setAdPlaying:NO];
-        }
-        playbackEvent = [[MUXSDKAdBreakEndEvent alloc] init];
-        [self setupAdViewDataAndDispatchEvent: playbackEvent];
-        if (_usesServerSideAdInsertion) {
-            [_playerBinding dispatchPlay];
-            [_playerBinding dispatchPlaying];
-        }
-    }
+    [self.adsListener dispatchPauseOrResume:isPause];
 }
 
 - (void)onContentPauseOrResume:(BOOL)isPause {
-    [self dispatchPauseOrResume:isPause];
+    [self.adsListener onContentPauseOrResume:isPause];
 }
 
 - (void)setupAdViewDataAndDispatchEvent:(MUXSDKAdEvent *) event {
-    [self setupAdViewData:event withAd:nil];
-    [_playerBinding dispatchAdEvent:event];
+    [self.adsListener setupAdViewDataAndDispatchEvent:event];
 }
 
 - (void)clientAdRequest:(IMAAdsRequest *)request {
-    _usesServerSideAdInsertion = NO;
-    _adRequestReported = YES;
-    
-    [self dispatchAdRequestForAdTag:request.adTagUrl];
+    [self.adsListener clientAdRequest:request];
 }
 
 - (void)daiAdRequest:(IMAStreamRequest *)request {
-    _usesServerSideAdInsertion = YES;
-    _adRequestReported = YES;
-    
-    [self dispatchAdRequestWithoutMetadata];
+    [self.adsListener daiAdRequest:request];
 }
 
 - (void)dispatchAdRequestWithoutMetadata {
-    MUXSDKAdEvent* playbackEvent = [[MUXSDKAdRequestEvent alloc] init];
-    [self setupAdViewDataAndDispatchEvent: playbackEvent];
+    [self.adsListener dispatchAdRequestWithoutMetadata];
 }
 
 - (void)dispatchAdRequestForAdTag:(nullable NSString *)adTagUrl {
-    MUXSDKAdEvent* playbackEvent = [[MUXSDKAdRequestEvent alloc] init];
-    MUXSDKAdData* adData = [[MUXSDKAdData alloc] init];
-    if(adTagUrl) {
-        self.adTagURL = adTagUrl;
-        adData.adTagUrl = adTagUrl;
-    }
-    
-    [self setupAdViewDataAndDispatchEvent: playbackEvent];
+    [self.adsListener dispatchAdRequestForAdTag:adTagUrl];
 }
 
 - (void)setPictureInPicture:(BOOL)isPictureInPicture {
-    _isPictureInPicture = isPictureInPicture;
+    [self.adsListener setPictureInPicture:isPictureInPicture];
 }
 
 /* IMAAdsManagerDelegate */
 
 - (void)adsManager:(IMAAdsManager *)adsManager didReceiveAdEvent:(IMAAdEvent *)event {
-    if (self.customerAdsManagerDelegate) {
-        [self.customerAdsManagerDelegate adsManager:adsManager didReceiveAdEvent:event];
-    }
-    [self dispatchEvent: event];
+    [self.adsListener adsManager:adsManager didReceiveAdEvent:event];
 }
 
 - (void)adsManager:(nonnull IMAAdsManager *)adsManager didReceiveAdError:(nonnull IMAAdError *)error {
-    if (self.customerAdsManagerDelegate) {
-        [self.customerAdsManagerDelegate adsManager:adsManager didReceiveAdError:error];
-    }
-    [self dispatchError: error.message];
+    [self.adsListener adsManager:adsManager
+               didReceiveAdError:error];
 }
 
 - (void)adsManagerDidRequestContentPause:(nonnull IMAAdsManager *)adsManager {
-    if (self.customerAdsManagerDelegate) {
-        [self.customerAdsManagerDelegate adsManagerDidRequestContentPause:adsManager];
-    }
-    // record content-pause last so adbreakstart happens after pause, to bracket the adbreak correctly
-    [self onContentPauseOrResume:true];
+    [self.adsListener adsManagerDidRequestContentPause:adsManager];
 }
 
 - (void)adsManagerDidRequestContentResume:(nonnull IMAAdsManager *)adsManager {
-    // record content-resume first so adbreakend happens before playing (brackets the ad break
-    [self onContentPauseOrResume:false];
-    if (self.customerAdsManagerDelegate) {
-        [self.customerAdsManagerDelegate adsManagerDidRequestContentResume:adsManager];
-    }
+    [self.adsListener adsManagerDidRequestContentResume:adsManager];
 }
 
 /* IMAAdsLoaderDelegate */
 
 - (void)adsLoader:(nonnull IMAAdsLoader *)loader adsLoadedWithData:(nonnull IMAAdsLoadedData *)adsLoadedData {
-    if (self.customerAdsLoaderDelegate) {
-        [self.customerAdsLoaderDelegate adsLoader:loader adsLoadedWithData:adsLoadedData];
-    }
-    [self.playerBinding dispatchAdEvent:[[MUXSDKAdResponseEvent alloc] init]];
+    [self.adsListener adsLoader:loader
+              adsLoadedWithData:adsLoadedData];
 }
 
 - (void)adsLoader:(nonnull IMAAdsLoader *)loader failedWithErrorData:(nonnull IMAAdLoadingErrorData *)adErrorData {
-    if (self.customerAdsLoaderDelegate) {
-        [self.customerAdsLoaderDelegate adsLoader:loader failedWithErrorData:adErrorData];
-    }
-    [self dispatchError:adErrorData.adError.message];
+    [self.adsListener adsLoader:loader
+            failedWithErrorData:adErrorData];
 }
 
 @end

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener+Private.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener+Private.h
@@ -1,0 +1,28 @@
+//
+//  MUXSDKIMAAdsListener+Private.h
+//  MuxStatsGoogleIMAPlugin
+//
+
+#import "MUXSDKIMAAdsListener.h"
+
+@interface MUXSDKIMAAdsListener(Private)
+
+NS_ASSUME_NONNULL_BEGIN
+
+- (nullable MUXSDKAdEvent *)dispatchEventOfType:(IMAAdEventType)eventType;
+- (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEventType)eventType
+                               withAdData:(nullable MUXSDKAdData *)adData
+                            withIMAAdData:(nullable NSDictionary *)imaAdData;
+- (void)dispatchError:(nullable NSString *)message;
+- (void)onContentPauseOrResume:(BOOL)isPause;
+
+- (void)setupAdViewData:(MUXSDKAdEvent *)event withAd:(IMAAd *)ad;
+- (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEvent *)event;
+- (void)dispatchPauseOrResume:(BOOL)isPause;
+- (void)setupAdViewDataAndDispatchEvent:(MUXSDKAdEvent *) event;
+- (void)dispatchAdRequestWithoutMetadata;
+- (void)dispatchAdRequestForAdTag:(nullable NSString *)adTagUrl;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
@@ -28,9 +28,9 @@ typedef NS_OPTIONS(NSUInteger, MUXSDKIMAAdsListenerOptions) {
 @property (nonatomic, weak, nullable) id<IMAAdsManagerDelegate> customerAdsManagerDelegate;
 @property (nonatomic, weak, nullable) id<IMAAdsLoaderDelegate> customerAdsLoaderDelegate;
 
-- (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
         monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader;
-- (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
                     options:(MUXSDKIMAAdsListenerOptions)options
         monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader;
 - (void)monitorAdsManager:(IMAAdsManager *)adsManager;

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
@@ -1,8 +1,7 @@
 //
-//  MUXSDKImaListener.h
-//  Expecta
-//
-//  Created by Dylan Jhaveri on 9/11/19.
+
+//  MUXSDKIMAAdsListener.h
+//  MuxStatsGoogleIMAPlugin
 //
 
 #import <Foundation/Foundation.h>
@@ -19,13 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MUXSDKPlayerBinding;
 
-typedef NS_OPTIONS(NSUInteger, MuxImaListenerOptions) {
-    MuxImaListenerOptionsNone                    = 0,
-    MuxImaListenerOptionsPictureInPicture        = 1 << 0,
+typedef NS_OPTIONS(NSUInteger, MUXSDKIMAAdsListenerOptions) {
+    MUXSDKIMAAdsListenerOptionsNone                    = 0,
+    MUXSDKIMAAdsListenerOptionsPictureInPicture        = 1 << 0,
 };
 
-NS_CLASS_DEPRECATED_IOS(2_0, 12_0, "Use MUXSDKIMAAdsListener instead.")
-@interface MuxImaListener : NSObject<IMAAdsManagerDelegate, IMAAdsLoaderDelegate>
+@interface MUXSDKIMAAdsListener : NSObject<IMAAdsManagerDelegate, IMAAdsLoaderDelegate>
 
 @property (nonatomic, weak, nullable) id<IMAAdsManagerDelegate> customerAdsManagerDelegate;
 @property (nonatomic, weak, nullable) id<IMAAdsLoaderDelegate> customerAdsLoaderDelegate;
@@ -33,7 +31,7 @@ NS_CLASS_DEPRECATED_IOS(2_0, 12_0, "Use MUXSDKIMAAdsListener instead.")
 - (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
         monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader;
 - (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
-                    options:(MuxImaListenerOptions)options
+                    options:(MUXSDKIMAAdsListenerOptions)options
         monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader;
 - (void)monitorAdsManager:(IMAAdsManager *)adsManager;
 - (void)setPictureInPicture:(BOOL)isPictureInPicture;

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener+Private.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener+Private.h
@@ -1,12 +1,9 @@
 //
-//  Header.h
-//  
+//  MuxImaListener+Private.h
+//
 //
 //  Created by Emily Dixon on 10/29/24.
 //
-
-#ifndef MuxImaListenerPrivate_h
-#define MuxImaListenerPrivate_h
 
 #import "MuxImaListener.h"
 
@@ -16,11 +13,9 @@
 - (nullable MUXSDKAdEvent *)dispatchEventOfType:(IMAAdEventType)eventType;
 // todo nice nullability
 - (nullable MUXSDKAdEvent *)dispatchEvent:(IMAAdEventType)eventType
-                                     withAdData:(nullable MUXSDKAdData *)adData 
-                                  withIMAAdData:(nullable NSDictionary *)imaAdData;
+                               withAdData:(nullable MUXSDKAdData *)adData
+                            withIMAAdData:(nullable NSDictionary *)imaAdData;
 - (void)dispatchError:(nullable NSString *)message;
-- (void)onContentPauseOrResume:(bool)isPause;
+- (void)onContentPauseOrResume:(BOOL)isPause;
 
 @end
-
-#endif /* MuxImaListenerPrivate_h */

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener.h
@@ -30,9 +30,9 @@ NS_CLASS_DEPRECATED_IOS(2_0, 12_0, "Use MUXSDKIMAAdsListener instead.")
 @property (nonatomic, weak, nullable) id<IMAAdsManagerDelegate> customerAdsManagerDelegate;
 @property (nonatomic, weak, nullable) id<IMAAdsLoaderDelegate> customerAdsLoaderDelegate;
 
-- (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
         monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader;
-- (id)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
+- (instancetype)initWithPlayerBinding:(MUXSDKPlayerBinding *)binding
                     options:(MuxImaListenerOptions)options
         monitoringAdsLoader:(nullable IMAAdsLoader *)adsLoader;
 - (void)monitorAdsManager:(IMAAdsManager *)adsManager;

--- a/Sources/MuxStatsGoogleIMAPlugin/include/module.modulemap
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/module.modulemap
@@ -1,8 +1,10 @@
 
 module MuxStatsGoogleIMAPlugin {
     header "MuxImaListener.h"
-    
+    header "MUXSDKIMAAdsListener.h"
+
     explicit module Private {
         header "MuxImaListener+Private.h"
+        header "MUXSDKIMAAdsListener+Private.h"
     }
 }

--- a/Sources/MuxStatsGoogleIMAPluginTests/GoogleIMAEventTests.swift
+++ b/Sources/MuxStatsGoogleIMAPluginTests/GoogleIMAEventTests.swift
@@ -21,7 +21,7 @@ final class GoogleIMAEventTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testMuxImaListenerInitialization() throws {
+    func testMUXSDKIMAAdsListenerInitialization() throws {
 
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
@@ -31,7 +31,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
         
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             monitoringAdsLoader: adsLoader
         )
@@ -40,7 +40,7 @@ final class GoogleIMAEventTests: XCTestCase {
 
     }
 
-    func testMuxImaListenerInitializationOptions() throws {
+    func testMUXSDKIMAAdsListenerInitializationOptions() throws {
 
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
@@ -50,7 +50,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -60,7 +60,7 @@ final class GoogleIMAEventTests: XCTestCase {
 
     }
 
-    func testMuxImaListenerStartedEvent() throws {
+    func testMUXSDKIMAAdsListenerStartedEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -69,7 +69,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -88,7 +88,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerFirstQuartileEvent() throws {
+    func testMUXSDKIMAAdsListenerFirstQuartileEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -97,7 +97,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -116,7 +116,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerMidpointEvent() throws {
+    func testMUXSDKIMAAdsListenerMidpointEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -125,7 +125,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -144,7 +144,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerThirdQuartileEvent() throws {
+    func testMUXSDKIMAAdsListenerThirdQuartileEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -153,7 +153,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -172,7 +172,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerSkippedEvent() throws {
+    func testMUXSDKIMAAdsListenerSkippedEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -181,7 +181,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -200,7 +200,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerCompleteEvent() throws {
+    func testMUXSDKIMAAdsListenerCompleteEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -209,7 +209,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -228,7 +228,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerPauseEvent() throws {
+    func testMUXSDKIMAAdsListenerPauseEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -237,7 +237,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader
@@ -256,7 +256,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerLogEventWithoutErrorData() throws {
+    func testMUXSDKIMAAdsListenerLogEventWithoutErrorData() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -265,7 +265,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             monitoringAdsLoader: adsLoader
         )
@@ -277,7 +277,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerLogEventWithErrorData() throws {
+    func testMUXSDKIMAAdsListenerLogEventWithErrorData() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -286,7 +286,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             monitoringAdsLoader: adsLoader
         )
@@ -315,7 +315,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
     }
 
-    func testMuxImaListenerTappedEvent() throws {
+    func testMUXSDKIMAAdsListenerTappedEvent() throws {
         let binding = try XCTUnwrap(
             MUXSDKPlayerBinding(
                 name: "",
@@ -324,7 +324,7 @@ final class GoogleIMAEventTests: XCTestCase {
         )
 
         let adsLoader = IMAAdsLoader()
-        let imaListener = MuxImaListener(
+        let imaListener = MUXSDKIMAAdsListener(
             playerBinding: binding,
             options: .pictureInPicture,
             monitoringAdsLoader: adsLoader


### PR DESCRIPTION
* deprecate and keep existing `MuxImaListener` type, forward all calls to it to new API transparently