### PR TITLE
update: Detect ad type

### DIFF
--- a/Examples/MuxStatsGoogleIMAPluginSPMExampleIOS/MuxStatsGoogleIMAPluginSPMExampleIOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/MuxStatsGoogleIMAPluginSPMExampleIOS/MuxStatsGoogleIMAPluginSPMExampleIOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "23027a473fc131a607f22d9077da969f5413192da31fa8032761eb1fb2c57c14",
+  "originHash" : "dbdc44e8c272d3c6ea5f4989e6947164e47cf954ba71108806c7bda804e23296",
   "pins" : [
     {
       "identity" : "mux-stats-sdk-avplayer",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/mux-stats-sdk-avplayer.git",
       "state" : {
-        "revision" : "9d4d18656216158a307330d96a0c54b3c35edbb0",
-        "version" : "4.1.2"
+        "revision" : "ed4e8a73372843ec4fe18822b0a8381519969162",
+        "version" : "4.10.0"
       }
     },
     {
@@ -15,8 +15,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/stats-sdk-objc.git",
       "state" : {
-        "revision" : "b75c77756b43d6dfe6d93c1f3445e23843d497ea",
-        "version" : "5.1.2"
+        "revision" : "645a23a8d8215ecdea2a557b04807a5a7ba6c554",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-interactive-media-ads-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios",
+      "state" : {
+        "revision" : "db4cbeb8c39f7c0fa2a28c52897e75288f6a3eaf",
+        "version" : "3.27.4"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-interactive-media-ads-tvos",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-tvos",
+      "state" : {
+        "revision" : "05109c3b19133c3495a32e5a0059bef917b5fde9",
+        "version" : "4.15.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/mux-stats-sdk-avplayer.git",
       "state" : {
-        "revision" : "dec068faeaeb94165057a3ca96ee8e04041a1c1f",
-        "version" : "4.1.0"
+        "revision" : "ed4e8a73372843ec4fe18822b0a8381519969162",
+        "version" : "4.10.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/stats-sdk-objc.git",
       "state" : {
-        "revision" : "856a4a6eb418b85d12b3c3435ecb615eb356c623",
-        "version" : "5.1.0"
+        "revision" : "645a23a8d8215ecdea2a557b04807a5a7ba6c554",
+        "version" : "5.7.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios",
       "state" : {
-        "revision" : "60c708f077d0d2aa02dfbfdeb60f2be8feb1c548",
-        "version" : "3.26.1"
+        "revision" : "db4cbeb8c39f7c0fa2a28c52897e75288f6a3eaf",
+        "version" : "3.27.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/muxinc/mux-stats-sdk-avplayer.git",
-            from: "4.1.0"
+            from: "4.10.0"
         ),
         .package(
             url: "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios",

--- a/Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m
+++ b/Sources/MuxStatsGoogleIMAPlugin/MUXSDKIMAAdsListener.m
@@ -89,6 +89,17 @@
         // is deprecated, but used for time being for parity
         // with web&android
         adData.adUniversalId = event.ad.universalAdIdValue;
+        
+        if (event.ad.adPodInfo != nil && !_usesServerSideAdInsertion) {
+            NSInteger podIndex = event.ad.adPodInfo.podIndex;
+            if (podIndex == 0) {
+                adData.adType = MUXSDKAdTypePreRoll;
+            } else if (podIndex < 0) {
+                adData.adType = MUXSDKAdTypePostRoll;
+            } else {
+                adData.adType = MUXSDKAdTypeMidRoll;
+            }
+        }
     }
 
     return [self dispatchEvent:event.type

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
@@ -111,7 +111,7 @@ typedef NS_OPTIONS(NSUInteger, MUXSDKIMAAdsListenerOptions) {
 /// just made
 - (void)clientAdRequest:(IMAAdsRequest *)request;
 
-/// Signals a stream ad request has been made by your
+/// Signals a DAI stream ad request has been made by your
 /// application.
 ///
 /// Call as soon as possible after sending the request to

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MUXSDKIMAAdsListener.h
@@ -5,11 +5,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_TV
-#import <MuxCore/MuxCoreTv.h>
-#else
 #import <MuxCore/MuxCore.h>
-#endif
 
 #import <MUXSDKStats/MUXSDKStats.h>
 #import <GoogleInteractiveMediaAds/GoogleInteractiveMediaAds.h>

--- a/Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener.h
+++ b/Sources/MuxStatsGoogleIMAPlugin/include/MuxImaListener.h
@@ -6,11 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_TV
-#import <MuxCore/MuxCoreTv.h>
-#else
 #import <MuxCore/MuxCore.h>
-#endif
 
 #import <MUXSDKStats/MUXSDKStats.h>
 #import <GoogleInteractiveMediaAds/GoogleInteractiveMediaAds.h>


### PR DESCRIPTION
For iOS, we use `podIndex` instead of `startOffset` because startOffset was always 0 in my testing