### PR TITLE
Fix FrameworkProject builds for xcframework generation

### DIFF
--- a/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.xcodeproj/project.pbxproj
+++ b/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.xcodeproj/project.pbxproj
@@ -497,16 +497,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/muxinc/mux-stats-sdk-avplayer";
 			requirement = {
-				kind = exactVersion;
-				version = 4.1.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.10.0;
 			};
 		};
 		190698382BB37B6700CE0FF7 /* XCRemoteSwiftPackageReference "swift-package-manager-google-interactive-media-ads-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios/";
 			requirement = {
-				kind = exactVersion;
-				version = 3.23.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.30.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FrameworkProject/MuxStatsGoogleIMAPlugin/MuxStatsGoogleIMAPlugin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/mux-stats-sdk-avplayer",
       "state" : {
-        "revision" : "dec068faeaeb94165057a3ca96ee8e04041a1c1f",
-        "version" : "4.1.0"
+        "revision" : "a8c04056f331218959fff89c9d249d7db6ecc73d",
+        "version" : "4.12.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/stats-sdk-objc.git",
       "state" : {
-        "revision" : "856a4a6eb418b85d12b3c3435ecb615eb356c623",
-        "version" : "5.1.0"
+        "revision" : "aba0b57a2fb75e154848b30ad8ec07283b520b75",
+        "version" : "5.11.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios/",
       "state" : {
-        "revision" : "8b8e3bbe0b8044cdfeedeadae3e8dc871017c31d",
-        "version" : "3.23.0"
+        "revision" : "9bd145421334f4c3a4650b2478b21a0aa842bffb",
+        "version" : "3.30.1"
       }
     }
   ],

--- a/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.xcodeproj/project.pbxproj
+++ b/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		1906984E2BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 190698452BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.framework */; };
 		190698542BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 190698482BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		190698622BB37BF400CE0FF7 /* MUXSDKStats in Frameworks */ = {isa = PBXBuildFile; productRef = 190698612BB37BF400CE0FF7 /* MUXSDKStats */; };
-		190698652BB37C7400CE0FF7 /* GoogleInteractiveMediaAds in Frameworks */ = {isa = PBXBuildFile; productRef = 190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAds */; };
+		190698652BB37C7400CE0FF7 /* GoogleInteractiveMediaAdsTvOS in Frameworks */ = {isa = PBXBuildFile; productRef = 190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAdsTvOS */; };
 		190698892BB3947F00CE0FF7 /* MuxStatsGoogleIMAPluginTVOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 190698522BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOSTests.m */; };
 		1915A2372CD186D40094AA27 /* MUXSDKIMAAdsListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 1915A2362CD186D40094AA27 /* MUXSDKIMAAdsListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1915A2392CD186ED0094AA27 /* MUXSDKIMAAdsListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 1915A2382CD186ED0094AA27 /* MUXSDKIMAAdsListener.m */; };
@@ -48,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				190698652BB37C7400CE0FF7 /* GoogleInteractiveMediaAds in Frameworks */,
+				190698652BB37C7400CE0FF7 /* GoogleInteractiveMediaAdsTvOS in Frameworks */,
 				190698622BB37BF400CE0FF7 /* MUXSDKStats in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -138,7 +138,7 @@
 			name = MuxStatsGoogleIMAPluginTVOS;
 			packageProductDependencies = (
 				190698612BB37BF400CE0FF7 /* MUXSDKStats */,
-				190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAds */,
+				190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAdsTvOS */,
 			);
 			productName = MuxStatsGoogleIMAPluginTVOS;
 			productReference = 190698452BB37B8E00CE0FF7 /* MuxStatsGoogleIMAPluginTVOS.framework */;
@@ -497,16 +497,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/muxinc/mux-stats-sdk-avplayer";
 			requirement = {
-				kind = exactVersion;
-				version = 4.1.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.10.0;
 			};
 		};
 		190698632BB37C7400CE0FF7 /* XCRemoteSwiftPackageReference "swift-package-manager-google-interactive-media-ads-tvos" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-tvos";
 			requirement = {
-				kind = exactVersion;
-				version = 4.13.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.16.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -517,10 +517,10 @@
 			package = 190698602BB37BF400CE0FF7 /* XCRemoteSwiftPackageReference "mux-stats-sdk-avplayer" */;
 			productName = MUXSDKStats;
 		};
-		190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAds */ = {
+		190698642BB37C7400CE0FF7 /* GoogleInteractiveMediaAdsTvOS */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 190698632BB37C7400CE0FF7 /* XCRemoteSwiftPackageReference "swift-package-manager-google-interactive-media-ads-tvos" */;
-			productName = GoogleInteractiveMediaAds;
+			productName = GoogleInteractiveMediaAdsTvOS;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FrameworkProject/MuxStatsGoogleIMAPluginTVOS/MuxStatsGoogleIMAPluginTVOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/mux-stats-sdk-avplayer",
       "state" : {
-        "revision" : "dec068faeaeb94165057a3ca96ee8e04041a1c1f",
-        "version" : "4.1.0"
+        "revision" : "a8c04056f331218959fff89c9d249d7db6ecc73d",
+        "version" : "4.12.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/stats-sdk-objc.git",
       "state" : {
-        "revision" : "856a4a6eb418b85d12b3c3435ecb615eb356c623",
-        "version" : "5.1.0"
+        "revision" : "aba0b57a2fb75e154848b30ad8ec07283b520b75",
+        "version" : "5.11.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-interactive-media-ads-tvos",
       "state" : {
-        "revision" : "a835dbc7dabeb1030c6f85aac63e8b44e67c15a0",
-        "version" : "4.13.0"
+        "revision" : "fe5a302eb17388077258b02e2a18e88f63100625",
+        "version" : "4.16.0"
       }
     }
   ],

--- a/scripts/create-dynamic-framework-ios.sh
+++ b/scripts/create-dynamic-framework-ios.sh
@@ -40,7 +40,8 @@ xcodebuild clean archive \
     -destination "generic/platform=iOS" \
     -archivePath "$BUILD_DIR/MuxStatsGoogleIMAPlugin.iOS.xcarchive" \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    ENABLE_MODULE_VERIFIER=NO | xcbeautify
 
 echo "▸ Creating iOS Simulator archive"
 
@@ -50,7 +51,8 @@ xcodebuild clean archive \
     -destination "generic/platform=iOS Simulator" \
     -archivePath "$BUILD_DIR/MuxStatsGoogleIMAPlugin.iOS-simulator.xcarchive" \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    ENABLE_MODULE_VERIFIER=NO | xcbeautify
 
 xcodebuild -create-xcframework \
     -framework "$BUILD_DIR/MuxStatsGoogleIMAPlugin.iOS.xcarchive/Products/Library/Frameworks/MuxStatsGoogleIMAPlugin.framework" \

--- a/scripts/create-dynamic-framework-tvos.sh
+++ b/scripts/create-dynamic-framework-tvos.sh
@@ -40,7 +40,8 @@ xcodebuild clean archive \
     -destination "generic/platform=tvOS" \
     -archivePath "$BUILD_DIR/MuxStatsGoogleIMAPluginTVOS.tvOS.xcarchive" \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    ENABLE_MODULE_VERIFIER=NO | xcbeautify
 
 echo "▸ Creating tvOS Simulator archive"
 
@@ -50,7 +51,8 @@ xcodebuild clean archive \
     -destination "generic/platform=tvOS Simulator" \
     -archivePath "$BUILD_DIR/MuxStatsGoogleIMAPluginTVOS.tvOS-simulator.xcarchive" \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    ENABLE_MODULE_VERIFIER=NO | xcbeautify
 
 xcodebuild -create-xcframework \
     -framework "$BUILD_DIR/MuxStatsGoogleIMAPluginTVOS.tvOS.xcarchive/Products/Library/Frameworks/MuxStatsGoogleIMAPluginTVOS.framework" \


### PR DESCRIPTION
## Summary

Follow-up to v0.17.0 release. These fixes were needed to get the xcframework build scripts working:

- **FrameworkProject SPM deps**: Were pinned to exact old versions (avplayer 4.1.0, IMA iOS 3.23.0, IMA tvOS 4.13.0). Updated to upToNextMajorVersion with correct minimums.
- **tvOS product rename**: Xcode project referenced `GoogleInteractiveMediaAds` but the tvOS SDK renamed it to `GoogleInteractiveMediaAdsTvOS` in v4.15.1.
- **Build scripts**: Added `ENABLE_MODULE_VERIFIER=NO` to work around Xcode 26 module verification failure with SPM dependencies.

## Test plan

- [x] `./scripts/create-dynamic-framework-ios.sh` builds successfully
- [x] `./scripts/create-dynamic-framework-tvos.sh` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)